### PR TITLE
Updates the styles of the button and remove two useless modifiers

### DIFF
--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -10,8 +10,6 @@
  *    - "-color-1": blue   ($color-1) - DEFAULT, optional class
  *    - "-color-2": orange ($color-6)
  *    - "-color-3": purple ($color-4)
- *    - "-color-4": white  ($color-3)
- *    - "-color-5": dark   ($color-2)
  *
  *  Other modifiers:
  *    - "-filled": button filled with the color (default outlined)
@@ -42,36 +40,29 @@
   font-weight: $font-weight-bold;
   text-transform: uppercase;
   color: $color-1;
-  border: 1px solid $color-1;
+  border: 1px solid rgba($color-1, .3);
   background: transparent;
   /* The cursor property needs to be specified for the buttons made with a
    * "button" HTML markup */
   cursor: pointer;
-  transition: box-shadow .15s;
+  transition: box-shadow .15s, border .15s;
   text-align: center;
 
-  &:hover {
-    box-shadow: 0px 7px 15px 0px rgba(0, 0, 0, .10);
-  }
+  &:hover { border-color: $color-1; }
+  &:active { background: rgba($color-1, .06); }
 
   &.-color-2 {
     color: $color-6;
-    border: 1px solid $color-6;
+    border: 1px solid rgba($color-6, .3);
+    &:hover { border-color: $color-6; }
+    &:active { background: rgba($color-6, .06); }
   }
 
   &.-color-3 {
     color: $color-4;
-    border: 1px solid $color-4;
-  }
-
-  &.-color-4 {
-    color: $color-3;
-    border: 1px solid $color-3;
-  }
-
-  &.-color-5 {
-    color: $color-2;
-    border: 1px solid $color-2;
+    border: 1px solid rgba($color-4, .3);
+    &:hover { border-color: $color-4; }
+    &:active { background: rgba($color-4, .06); }
   }
 
   &.-respect-text {
@@ -94,11 +85,20 @@
       background: $color-4;
       border-color: $color-4;
     }
+
+    &:hover {
+      box-shadow: 0px 7px 15px 0px rgba(0, 0, 0, .10);
+    }
+
+    &:active {
+      box-shadow: none;
+    }
   }
 
   &.-inverse {
     color: $color-3;
     border-color: $color-3;
+    &:active { background: rgba($color-3, .06); }
 
     &.-filled {
       background: $color-3;


### PR DESCRIPTION
This PR updates the styles of the buttons to respect the UI kit.

Additionally, it removes two color modifiers: the white (`-color-3`) because it makes no sense due to the `-inverse` option and because it introduced some issues (it hasn't been tested enough) ; and  the dark (`-color-4`) because this color is never used.
