### PR TITLE
infowindow tooltip fixes

### DIFF
--- a/app/assets/javascripts/helpers/layers/marker_cluster_layer.js
+++ b/app/assets/javascripts/helpers/layers/marker_cluster_layer.js
@@ -39,6 +39,7 @@
     };
 
     pruneCluster.PrepareLeafletMarker = function(leafletMarker, data) {
+      console.log(data.feature.properties)
       var htmlContent = infowindowTemplate(data.feature.properties);
       var icon = circleIcon;
       if (data.feature.properties.is_project_lead || params.data === 'events') {

--- a/app/assets/javascripts/helpers/layers/marker_cluster_layer.js
+++ b/app/assets/javascripts/helpers/layers/marker_cluster_layer.js
@@ -39,7 +39,6 @@
     };
 
     pruneCluster.PrepareLeafletMarker = function(leafletMarker, data) {
-      console.log(data.feature.properties)
       var htmlContent = infowindowTemplate(data.feature.properties);
       var icon = circleIcon;
       if (data.feature.properties.is_project_lead || params.data === 'events') {

--- a/app/assets/javascripts/helpers/layers/points_cluster_layer.js
+++ b/app/assets/javascripts/helpers/layers/points_cluster_layer.js
@@ -33,7 +33,11 @@
         className: 'point-icon ' + className,
         html: ''
       });
-      var htmlContent = infowindowTemplate(data.feature.properties);
+      var infowindowData = data.feature.properties;
+      if(infowindowData.type !== 'point'){
+        infowindowData[infowindowData.type] = infowindowData.id || infowindowData.location_id;
+      }
+      var htmlContent = infowindowTemplate(infowindowData);
       leafletMarker.setIcon(pointIcon);
       leafletMarker.bindPopup(htmlContent);
     };

--- a/app/assets/javascripts/templates/infowindow.hbs
+++ b/app/assets/javascripts/templates/infowindow.hbs
@@ -1,12 +1,17 @@
 <div class="c-infowindow">
   {{#if project}}
     <h3><a href="/projects/{{project}}">{{title}}</a></h3>
-    <a href="/investigators/{{investigator}}">{{investigator_name}}</a>
-    {{#if is_project_lead}}
-      <span class="c-tag">Project lead</span>
+    {{#if investigator}}
+      <a href="/investigators/{{investigator}}">{{investigator_name}}</a>
+      {{#if is_project_lead}}
+        <span class="c-tag">Project lead</span>
+      {{/if}}
     {{/if}}
   {{/if}}
   {{#if event}}
     <h3><a href="/events/{{event}}">{{title}}</a></h3>
+  {{/if}}
+  {{#if resource_id}}
+    <h3><a href="/investigators/{{resource_id}}">{{resource_name}}</a></h3>
   {{/if}}
 </div>


### PR DESCRIPTION
This PR fixes the following issues:

- On main map: People map point's infowindow tooltip was empty, now it shows investigators name.
- On project's detail map: Project point's infowindow tooltip was empty, now it shows project's name.
- On event's detail map: Event point's infowindow tooltip was empty, now it shows event's name.

I believe that the API's object that is sent to the project's detail page could be modified to match the main map's object structure; this way, the infowindow could also show investigator's name.