### PR TITLE
filter returns no layers issue

### DIFF
--- a/app/assets/javascripts/presenters/map_presenter.js
+++ b/app/assets/javascripts/presenters/map_presenter.js
@@ -110,14 +110,16 @@
         this.map.removeLayer(this.currentLayer);
       }
       this.fc.getLayer(this.getState()).done(function(layer) {
-        var bounds = layer.getBounds();
-        this.currentLayer = layer;
-        this.map.addLayer(this.currentLayer);
-        if (bounds && !this.options.noAnimateBounds) {
-          this.map.map.fitBounds(bounds, {
-            padding: [50, 50]
-          });
-        }
+        if(!jQuery.isEmptyObject(layer._layers)){
+          var bounds = layer.getBounds();
+          this.currentLayer = layer;
+          this.map.addLayer(this.currentLayer);
+          if (bounds && !this.options.noAnimateBounds) {
+            this.map.map.fitBounds(bounds, {
+              padding: [50, 50]
+            });
+          }
+      }
       }.bind(this));
     },
 


### PR DESCRIPTION
This PR fixes an issue that occurred when a filter was set and it returned no layers.
Now checks if there are layers to be display before trying to display them.