### PR TITLE
Fix: marker layer bug

### DIFF
--- a/app/assets/javascripts/facades/layer_facade.js
+++ b/app/assets/javascripts/facades/layer_facade.js
@@ -2,12 +2,6 @@
 
   'use strict';
 
-  var blubbleSizes = {
-    big: 90,
-    medium: 65,
-    small: 45
-  };
-
   var layerFacade = {
 
     getLayer: function(params) {
@@ -34,10 +28,11 @@
         .done(function() {
           var layer;
           var geoJson = locations.toGeoJSON();
+
           if (params['countries[]']) {
-            layer = App.helper.markerClusterLayer(geoJson, params);
+            layer = (geoJson.features.length) ? App.helper.markerClusterLayer(geoJson, params) : null;
           } else {
-            layer = App.helper.bubbleLayer(geoJson, params, layerFacade);
+            layer = (geoJson.features.length) ? App.helper.bubbleLayer(geoJson, params, layerFacade) : null;
           }
           deferred.resolve(layer);
         });
@@ -45,7 +40,7 @@
       return deferred.promise();
     },
 
-    getPointLayer: function(params) {
+    getPointLayer: function() {
       var fetchParams = Object.assign(gon.server_params, { group: 'points' });
       var deferred = new $.Deferred();
       var locations = new App.Collection.Locations();

--- a/app/assets/javascripts/presenters/map_presenter.js
+++ b/app/assets/javascripts/presenters/map_presenter.js
@@ -110,7 +110,8 @@
         this.map.removeLayer(this.currentLayer);
       }
       this.fc.getLayer(this.getState()).done(function(layer) {
-        if(!jQuery.isEmptyObject(layer._layers)){
+
+        if (layer) {
           var bounds = layer.getBounds();
           this.currentLayer = layer;
           this.map.addLayer(this.currentLayer);
@@ -119,7 +120,8 @@
               padding: [50, 50]
             });
           }
-      }
+        }
+        
       }.bind(this));
     },
 

--- a/app/assets/stylesheets/components/_share-social.scss
+++ b/app/assets/stylesheets/components/_share-social.scss
@@ -1,6 +1,6 @@
 .c-share-social {
   display: flex;
-  justify-content: flex-start;
+  justify-content: center;
 
   a {
     display: block;


### PR DESCRIPTION
This PR removes `if(!jQuery.isEmptyObject(layer._layers))` from the map_presenter because it dind't display the `markerClusterLayer` markers.