### PR TITLE
Lists: show more button path

### DIFF
--- a/app/views/events/_list.html.erb
+++ b/app/views/events/_list.html.erb
@@ -34,7 +34,9 @@
       <div class="c-card">
         <% page = @page + 1 %>
         <%= link_to (t 'show_more'),
-          map_path(request.query_parameters.merge({ page: page })),
+          {
+            :params => request.query_parameters.merge({ page: page })
+          },
           class: "c-btn -circle",
           id: 'showMoreButton',
           remote: true

--- a/app/views/investigators/_list.html.erb
+++ b/app/views/investigators/_list.html.erb
@@ -24,8 +24,9 @@
       <div class="c-card">
         <% page = @page + 1 %>
         <%= link_to (t 'show_more'),
-          {:path => request.path,
-          :params => request.query_parameters.merge({ page: page })},
+          {
+            :params => request.query_parameters.merge({ page: page })
+          },
           class: "c-btn -circle",
           id: 'showMoreButton',
           remote: true

--- a/app/views/projects/_list.html.erb
+++ b/app/views/projects/_list.html.erb
@@ -40,7 +40,9 @@
       <div class="c-card">
         <% page = @page + 1 %>
         <%= link_to (t 'show_more'),
-          map_path(request.query_parameters.merge({ page: page })),
+          {
+            :params => request.query_parameters.merge({ page: page })
+          },
           class: "c-btn -circle",
           id: 'showMoreButton',
           remote: true


### PR DESCRIPTION
This PR set the `show more button path` to the current location. Or better, it doesn't set any path, so the link will always point the current location.