### PR TITLE
restores pointer-events none to l-app-title that was removed

### DIFF
--- a/app/assets/stylesheets/layouts/_app.scss
+++ b/app/assets/stylesheets/layouts/_app.scss
@@ -66,9 +66,7 @@
     color: $inverse-font-color;
 
     background-image: linear-gradient(to top, #68299b, rgba(103, 40, 155, 0));
-
-    // I need to click in the follow buttons
-    // pointer-events: none;
+    pointer-events: none;
   }
 
   .l-app-bottombar {


### PR DESCRIPTION
This PR restores the **pointer-events: none** that was taken, because another solution has already been merged with develop before, and now both markers and buttons are clickable. Woo-hoo!