### PR TITLE
Events: ordered by start date

### DIFF
--- a/app/controllers/countries_controller.rb
+++ b/app/controllers/countries_controller.rb
@@ -17,7 +17,7 @@ class CountriesController < ApplicationController
 
     limit = 12 + (@page * 9)
 
-    @events = Event.fetch_all(countries: params[:iso]).distinct.order('created_at DESC')
+    @events = Event.fetch_all(countries: params[:iso]).distinct.order('start_date DESC NULLS LAST')
     @projects = Project.fetch_all(countries: params[:iso]).distinct.order('created_at DESC')
     @people = Investigator.fetch_all(countries: params[:iso]).distinct.order('created_at DESC')
     @posts = @country.posts

--- a/app/controllers/investigators_controller.rb
+++ b/app/controllers/investigators_controller.rb
@@ -30,7 +30,7 @@ class InvestigatorsController < ApplicationController
 
     @projects = Project.fetch_all(investigators: @investigator.id).order('created_at DESC')
     @posts = Post.where(user_id: @investigator.id)
-    @events = Event.fetch_all(user: @investigator_user && @investigator_user.id || -1).order('created_at DESC')
+    @events = Event.fetch_all(user: @investigator_user && @investigator_user.id || -1).order('start_date DESC NULLS LAST')
 
     if params.key?(:data) && params[:data] == 'posts'
       @items = @posts.first(limit)

--- a/app/controllers/map_controller.rb
+++ b/app/controllers/map_controller.rb
@@ -15,7 +15,7 @@ class MapController < ApplicationController
     limit = 12 + (@page * 9)
 
     if params.key?(:data) && params[:data] == 'events'
-      events = Event.fetch_all(projects_params).order(sort_param)
+      events = Event.fetch_all(events_params).order('start_date DESC NULLS LAST')
       # Get public and private events
       public , private = [], []
       events.each do |event|
@@ -28,7 +28,7 @@ class MapController < ApplicationController
       @items_private_total = private.size
       @items_total = events.size
     elsif params.key?(:data) && params[:data] == 'people'
-      people = Investigator.fetch_all(people_params).order('created_At DESC')
+      people = Investigator.fetch_all(people_params).order('created_at DESC')
       @items = people.limit(limit)
       @more = (people.size > @items.size)
       @items_total = people.size
@@ -52,6 +52,11 @@ class MapController < ApplicationController
       params.permit(:sortby, :user, :start_date, :end_date, regions:[], countries:[], project_types:[], cancer_types:[], organization_types:[], organizations:[], investigators:[], funding_sources:[])
     end
 
+    def events_params
+      # I decide to not allow the sortby param as long as they want to order events always by upcoming events. If it is not the desired behaviour we will need to change a lot of things
+      params.permit(:user, :start_date, :end_date, regions:[], countries:[], project_types:[], cancer_types:[], organization_types:[], organizations:[], investigators:[], funding_sources:[])
+    end
+
     def investigators_params
       params.permit(:data, :sortby, :start_date, :end_date, regions:[], countries:[], project_types:[], cancer_types:[], organization_types:[], organizations:[])
     end
@@ -71,9 +76,9 @@ class MapController < ApplicationController
       when 'created_desc'
         @sortby = 'created_at DESC'
       when 'start_date_asc'
-        @sortby = 'start_date ASC'
+        @sortby = 'start_date ASC NULLS LAST'
       when 'start_date_desc'
-        @sortby = 'start_date DESC'
+        @sortby = 'start_date DESC NULLS LAST'
       else
         @sortby = 'title ASC'
       end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -16,7 +16,7 @@ class OrganizationsController < ApplicationController
 
     limit = 12 + (@page * 9)
 
-    @events = Event.fetch_all(organizations: @organization.id).order('events.created_at DESC')
+    @events = Event.fetch_all(organizations: @organization.id).order('start_date DESC NULLS LAST')
     @projects = Project.fetch_all(organizations: @organization.id).order('projects.created_at DESC')
     @people = Investigator.fetch_all(organizations: @organization.id).order('organizations.created_at DESC')
     @posts = @organization.posts

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,7 +24,7 @@ class UsersController < ApplicationController
     @projects = @user.projects.order('created_at DESC')
     @people = @user.investigator
     @posts = @user.posts
-    @events = @user.events.order('created_at DESC')
+    @events = @user.events.order('start_date DESC NULLS LAST')
     @conversations = Mailboxer::Conversation.joins(:receipts).where(mailboxer_receipts: { receiver_id: current_user.id, deleted: false }).uniq.page(params[:page]).order('created_at DESC')
 
     if params.key?(:data) && params[:data] == 'network'

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -73,8 +73,8 @@ class Event < ApplicationRecord
       events = events.order('events.created_at DESC')      if options[:sortby] && options[:sortby] == 'created_desc'
       events = events.order('events.title ASC')            if options[:sortby] && options[:sortby] == 'title_asc'
       events = events.order('events.title DESC')           if options[:sortby] && options[:sortby] == 'title_desc'
-      events = events.order('events.start_date ASC')       if options[:sortby] && options[:sortby] == 'start_date_asc'
-      events = events.order('events.start_date DESC')      if options[:sortby] && options[:sortby] == 'start_date_desc'
+      events = events.order('events.start_date ASC NULLS LAST')       if options[:sortby] && options[:sortby] == 'start_date_asc'
+      events = events.order('events.start_date DESC NULLS LAST')      if options[:sortby] && options[:sortby] == 'start_date_desc'
       events.distinct
     end
 


### PR DESCRIPTION
We need to improve the behavior but for the moment is better than before. 
- Right now we always order the events by start date DESC NULLS LAST. 
- The problem is that we don't change the sortby dropdown because we need to figure out how we are going to do it. That opens a lot of questions... Because we are going to change automatically the sortby dropdown without an interaction of the user, and there are options that don't belong to projects (like start_date_asc and start_date_desc) 